### PR TITLE
Bugfix: Disabled shuffling to preserve order of elements in test set

### DIFF
--- a/lesson-5-Building-Evaluating-and-Interpreting-Models-for-Bias-and-Uncertainty/Lesson_4_screencast.ipynb
+++ b/lesson-5-Building-Evaluating-and-Interpreting-Models-for-Bias-and-Uncertainty/Lesson_4_screencast.ipynb
@@ -717,11 +717,12 @@
    "outputs": [],
    "source": [
     "#adapted from https://www.tensorflow.org/tutorials/structured_data/feature_columns\n",
-    "def df_to_dataset(df, predictor,  batch_size=32):\n",
+    "def df_to_dataset(df, predictor,  batch_size=32, shuffle=True):\n",
     "    df = df.copy()\n",
     "    labels = df.pop(predictor)\n",
     "    ds = tf.data.Dataset.from_tensor_slices((dict(df), labels))\n",
-    "    ds = ds.shuffle(buffer_size=len(df))\n",
+    "    if shuffle:\n",
+    "        ds = ds.shuffle(buffer_size=len(df))\n",
     "    ds = ds.batch(batch_size)\n",
     "    return ds"
    ]
@@ -735,7 +736,7 @@
     "PREDICTOR_FIELD = 'MPG'\n",
     "batch_size = 128\n",
     "train_ds = df_to_dataset(train_data, PREDICTOR_FIELD, batch_size=batch_size)\n",
-    "test_ds = df_to_dataset(test_data, PREDICTOR_FIELD, batch_size=batch_size)"
+    "test_ds = df_to_dataset(test_data, PREDICTOR_FIELD, batch_size=batch_size, shuffle=False)"
    ]
   },
   {

--- a/lesson-5-Building-Evaluating-and-Interpreting-Models-for-Bias-and-Uncertainty/exercises/solution/Lesson_Modeling_Exercises_Solutions.ipynb
+++ b/lesson-5-Building-Evaluating-and-Interpreting-Models-for-Bias-and-Uncertainty/exercises/solution/Lesson_Modeling_Exercises_Solutions.ipynb
@@ -364,11 +364,12 @@
    "outputs": [],
    "source": [
     "#adapted from https://www.tensorflow.org/tutorials/structured_data/feature_columns\n",
-    "def df_to_dataset(df, predictor,  batch_size=32):\n",
+    "def df_to_dataset(df, predictor,  batch_size=32, shuffle=True):\n",
     "    df = df.copy()\n",
     "    labels = df.pop(predictor)\n",
     "    ds = tf.data.Dataset.from_tensor_slices((dict(df), labels))\n",
-    "    ds = ds.shuffle(buffer_size=len(df))\n",
+    "    if shuffle:\n",
+    "        ds = ds.shuffle(buffer_size=len(df))\n",
     "    ds = ds.batch(batch_size)\n",
     "    return ds"
    ]
@@ -393,7 +394,7 @@
     "PREDICTOR_FIELD = 'trestbps'\n",
     "batch_size = 128\n",
     "train_ds = df_to_dataset(train_dataset, PREDICTOR_FIELD, batch_size=batch_size)\n",
-    "test_ds = df_to_dataset(test_dataset, PREDICTOR_FIELD, batch_size=batch_size)"
+    "test_ds = df_to_dataset(test_dataset, PREDICTOR_FIELD, batch_size=batch_size, shuffle=False)"
    ]
   },
   {

--- a/lesson-5-Building-Evaluating-and-Interpreting-Models-for-Bias-and-Uncertainty/exercises/starter/Lesson_Modeling_Exercise_3_Starter_Code.ipynb
+++ b/lesson-5-Building-Evaluating-and-Interpreting-Models-for-Bias-and-Uncertainty/exercises/starter/Lesson_Modeling_Exercise_3_Starter_Code.ipynb
@@ -121,11 +121,12 @@
    "outputs": [],
    "source": [
     "#adapted from https://www.tensorflow.org/tutorials/structured_data/feature_columns\n",
-    "def df_to_dataset(df, predictor,  batch_size=32):\n",
+    "def df_to_dataset(df, predictor,  batch_size=32, shuffle=True):\n",
     "    df = df.copy()\n",
     "    labels = df.pop(predictor)\n",
     "    ds = tf.data.Dataset.from_tensor_slices((dict(df), labels))\n",
-    "    ds = ds.shuffle(buffer_size=len(df))\n",
+    "    if shuffle:\n",
+    "        ds = ds.shuffle(buffer_size=len(df))\n",
     "    ds = ds.batch(batch_size)\n",
     "    return ds"
    ]
@@ -150,7 +151,7 @@
     "PREDICTOR_FIELD = 'trestbps'\n",
     "batch_size = 128\n",
     "train_ds = df_to_dataset(train_dataset, PREDICTOR_FIELD, batch_size=batch_size)\n",
-    "test_ds = df_to_dataset(test_dataset, PREDICTOR_FIELD, batch_size=batch_size)"
+    "test_ds = df_to_dataset(test_dataset, PREDICTOR_FIELD, batch_size=batch_size, shuffle=False)"
    ]
   },
   {

--- a/project/starter_code/student_project.ipynb
+++ b/project/starter_code/student_project.ipynb
@@ -679,8 +679,8 @@
     "# Convert dataset from Pandas dataframes to TF dataset \n",
     "batch_size = 128\n",
     "diabetes_train_ds = df_to_dataset(d_train, PREDICTOR_FIELD, batch_size=batch_size)\n",
-    "diabetes_val_ds = df_to_dataset(d_val, PREDICTOR_FIELD, batch_size=batch_size)\n",
-    "diabetes_test_ds = df_to_dataset(d_test, PREDICTOR_FIELD, batch_size=batch_size)"
+    "diabetes_val_ds = df_to_dataset(d_val, PREDICTOR_FIELD, batch_size=batch_size, shuffle=False)\n",
+    "diabetes_test_ds = df_to_dataset(d_test, PREDICTOR_FIELD, batch_size=batch_size, shuffle=False)"
    ]
   },
   {

--- a/project/starter_code/utils.py
+++ b/project/starter_code/utils.py
@@ -34,11 +34,12 @@ def preprocess_df(df, categorical_col_list, numerical_col_list, predictor, categ
     return df
 
 #adapted from https://www.tensorflow.org/tutorials/structured_data/feature_columns
-def df_to_dataset(df, predictor,  batch_size=32):
+def df_to_dataset(df, predictor,  batch_size=32, shuffle=True):
     df = df.copy()
     labels = df.pop(predictor)
     ds = tf.data.Dataset.from_tensor_slices((dict(df), labels))
-    ds = ds.shuffle(buffer_size=len(df))
+    if shuffle:
+        ds = ds.shuffle(buffer_size=len(df))
     ds = ds.batch(batch_size)
     return ds
 


### PR DESCRIPTION
Bugfix of issue #4 

Fixed files which create a test/validation set, including the **final project**,  by searching for `_ds = df_to_dataset`.